### PR TITLE
feat: add sentinel and remove data source for consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following requirements are needed by this module:
 The following resources are used by this module:
 
 - [azapi_resource.data_collection_rule](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.sentinel_onboarding_state](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_automation_account.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_account) (resource)
 - [azurerm_log_analytics_linked_service.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_service) (resource)
 - [azurerm_log_analytics_solution.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_solution) (resource)
@@ -55,7 +56,6 @@ The following resources are used by this module:
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
-- [azurerm_resource_group.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -235,51 +235,7 @@ Default:
 ```json
 [
   {
-    "product": "OMSGallery/AgentHealthAssessment",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/AntiMalware",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/ChangeTracking",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/ContainerInsights",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/Security",
-    "publisher": "Microsoft"
-  },
-  {
     "product": "OMSGallery/SecurityInsights",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/ServiceMap",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/SQLAdvancedThreatProtection",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/SQLAssessment",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/SQLVulnerabilityAssessment",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/Updates",
-    "publisher": "Microsoft"
-  },
-  {
-    "product": "OMSGallery/VMInsights",
     "publisher": "Microsoft"
   }
 ]
@@ -360,6 +316,14 @@ Default: `"PerGB2018"`
 ### <a name="input_resource_group_creation_enabled"></a> [resource\_group\_creation\_enabled](#input\_resource\_group\_creation\_enabled)
 
 Description: A boolean flag to determine whether to deploy the Azure Resource Group or not.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_sentinel_enabled"></a> [sentinel\_enabled](#input\_sentinel\_enabled)
+
+Description: A boolean flag to determine whether to deploy the Sentinel onboardingStates configuration or not.
 
 Type: `bool`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The following resources are used by this module:
 - [azapi_resource.sentinel_onboarding_state](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_automation_account.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_account) (resource)
 - [azurerm_log_analytics_linked_service.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_service) (resource)
-- [azurerm_log_analytics_solution.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_solution) (resource)
 - [azurerm_log_analytics_workspace.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_resource_group.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
@@ -216,30 +215,6 @@ Description: A boolean flag to determine whether to deploy the Azure Automation 
 Type: `bool`
 
 Default: `true`
-
-### <a name="input_log_analytics_solution_plans"></a> [log\_analytics\_solution\_plans](#input\_log\_analytics\_solution\_plans)
-
-Description: The Log Analytics Solution Plans to create.
-
-Type:
-
-```hcl
-list(object({
-    product   = string
-    publisher = optional(string, "Microsoft")
-  }))
-```
-
-Default:
-
-```json
-[
-  {
-    "product": "OMSGallery/SecurityInsights",
-    "publisher": "Microsoft"
-  }
-]
-```
 
 ### <a name="input_log_analytics_workspace_allow_resource_only_permissions"></a> [log\_analytics\_workspace\_allow\_resource\_only\_permissions](#input\_log\_analytics\_workspace\_allow\_resource\_only\_permissions)
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  resource_group_name        = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].name : data.azurerm_resource_group.management[0].name
-  resource_group_resource_id = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].id : data.azurerm_resource_group.management[0].id
+  resource_group_name        = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].name : var.resource_group_name
+  resource_group_resource_id = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].id : null
 }

--- a/main.tf
+++ b/main.tf
@@ -61,24 +61,11 @@ resource "azurerm_log_analytics_linked_service" "management" {
   write_access_id     = null
 }
 
-resource "azurerm_log_analytics_solution" "management" {
-  for_each = { for plan in toset(var.log_analytics_solution_plans) : "${plan.publisher}/${plan.product}" => plan }
-
-  location              = var.location
-  resource_group_name   = local.resource_group_name
-  solution_name         = basename(each.value.product)
-  workspace_name        = var.log_analytics_workspace_name
-  workspace_resource_id = azurerm_log_analytics_workspace.management.id
-  tags                  = var.tags
-
-  plan {
-    product   = each.value.product
-    publisher = each.value.publisher
+removed {
+  from = azurerm_log_analytics_linked_service.management["Microsoft/OMSGallery/SecurityInsights"]
+  lifecycle {
+    destroy = false
   }
-
-  depends_on = [
-    azurerm_log_analytics_linked_service.management,
-  ]
 }
 
 resource "azurerm_user_assigned_identity" "management" {

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,6 @@ resource "azurerm_resource_group" "management" {
   tags     = var.tags
 }
 
-data "azurerm_resource_group" "management" {
-  count = var.resource_group_creation_enabled ? 0 : 1
-
-  name = var.resource_group_name
-}
-
 resource "azurerm_log_analytics_workspace" "management" {
   location                           = var.location
   name                               = var.log_analytics_workspace_name
@@ -106,4 +100,16 @@ resource "azapi_resource" "data_collection_rule" {
   parent_id                 = local.resource_group_resource_id
   schema_validation_enabled = each.value.schema_validation_enabled
   tags                      = each.value.tags
+}
+
+resource "azapi_resource" "sentinel_onboarding_state" {
+  type      = "Microsoft.SecurityInsights/onboardingStates@2024-03-01"
+  name      = default
+  parent_id = azurerm_log_analytics_workspace.management.id
+  location  = var.location
+  body = {
+    properties = {
+      customerManagedKey = var.log_analytics_workspace_cmk_for_query_forced
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,51 +126,7 @@ variable "log_analytics_solution_plans" {
   }))
   default = [
     {
-      product   = "OMSGallery/AgentHealthAssessment"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/AntiMalware"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/ChangeTracking"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/ContainerInsights"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/Security"
-      publisher = "Microsoft"
-    },
-    {
       product   = "OMSGallery/SecurityInsights"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/ServiceMap"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/SQLAdvancedThreatProtection"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/SQLAssessment"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/SQLVulnerabilityAssessment"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/Updates"
-      publisher = "Microsoft"
-    },
-    {
-      product   = "OMSGallery/VMInsights"
       publisher = "Microsoft"
     },
   ]
@@ -266,4 +222,11 @@ variable "user_assigned_managed_identities" {
     }
   }
   description = "Enables customisation of the user assigned managed identities."
+}
+
+variable "sentinel_enabled" {
+  type        = bool
+  default     = true
+  description = "A boolean flag to determine whether to deploy the Sentinel onboardingStates configuration or not."
+  nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,21 +119,6 @@ variable "linked_automation_account_creation_enabled" {
   nullable    = false
 }
 
-variable "log_analytics_solution_plans" {
-  type = list(object({
-    product   = string
-    publisher = optional(string, "Microsoft")
-  }))
-  default = [
-    {
-      product   = "OMSGallery/SecurityInsights"
-      publisher = "Microsoft"
-    },
-  ]
-  description = "The Log Analytics Solution Plans to create."
-  nullable    = false
-}
-
 variable "log_analytics_workspace_allow_resource_only_permissions" {
   type        = bool
   default     = true


### PR DESCRIPTION
Added new way to deploy sentinel - in future we can remove the solution way.

Also removed data source, can't see it's necessary really. If the RG doesn't exist it'll fail anyway.