### PR TITLE
Feat add SQL ATP stream to defender DCR

### DIFF
--- a/locals.data-collection-rules.tf
+++ b/locals.data-collection-rules.tf
@@ -295,6 +295,7 @@ locals {
                   "Microsoft-DefenderForSqlTelemetry",
                   "Microsoft-DefenderForSqlScanEvents",
                   "Microsoft-DefenderForSqlScanResults",
+                  "Microsoft-SqlAtpStatus-DefenderForSql"
                 ],
                 extensionSettings = {
                   enableCollectionOfSqlQueriesForSecurityResearch = var.data_collection_rules.defender_sql.enable_collection_of_sql_queries_for_security_research
@@ -318,6 +319,7 @@ locals {
                 "Microsoft-DefenderForSqlTelemetry",
                 "Microsoft-DefenderForSqlScanEvents",
                 "Microsoft-DefenderForSqlScanResults",
+                "Microsoft-SqlAtpStatus-DefenderForSql"
               ],
               destinations = [
                 "LogAnalyticsDest"


### PR DESCRIPTION
## Description

Added SQL Advanced Threat Protection status log to data collection rule. The logs allows identifying machines connected to the workspace with SQL ATP and the protection status on each instance on those machines and is used by MDfC Defender for SQL.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
