### PR TITLE
resource locks for mgmt resources

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -78,4 +78,16 @@ module "management" {
       name = "uami-ama-${random_id.id.hex}"
     }
   }
+  management_resource_locks = {
+    automation_account = {
+      enabled = true
+    }
+    data_collection_rules = {
+      enabled    = true
+      lock_level = "ReadOnly"
+    }
+    user_assigned_identities = {
+      enabled = true
+    }
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -13,14 +13,12 @@ locals {
       for lock_name, lock_config in var.management_resource_locks : lock_name => {
         lock_level = lock_config.lock_level
         scope = (
-          lock_name == "resource_group" ? azurerm_resource_group.management[0].id :
           lock_name == "log_analytics" ? azurerm_log_analytics_workspace.management.id :
           lock_name == "automation_account" ? azurerm_automation_account.management[0].id :
           lock_name == "user_assigned_identities" ? azurerm_user_assigned_identity.management["ama"].id : null
         )
         } if lock_config.enabled && (
         # Check if the corresponding resource actually exists using the same variables
-        lock_name == "resource_group" ? var.resource_group_creation_enabled :
         lock_name == "log_analytics" ? true : # Log analytics always exists  
         lock_name == "automation_account" ? var.linked_automation_account_creation_enabled :
         lock_name == "user_assigned_identities" ? var.user_assigned_managed_identities.ama.enabled :

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,37 @@
 locals {
   resource_group_name        = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].name : var.resource_group_name
   resource_group_resource_id = var.resource_group_creation_enabled ? azurerm_resource_group.management[0].id : provider::azapi::build_resource_id("/subscriptions/${data.azapi_client_config.current.subscription_id}", "Microsoft.Resources/resourceGroups", var.resource_group_name)
+
+
+  enabled_data_collection_rules = {
+    for rule_name, rule_config in var.data_collection_rules : rule_name => rule_config
+    if rule_config.enabled
+  }
+
+  resource_locks_processed = merge(
+    {
+      for lock_name, lock_config in var.management_resource_locks : lock_name => {
+        lock_level = lock_config.lock_level
+        scope = (
+          lock_name == "resource_group" ? azurerm_resource_group.management[0].id :
+          lock_name == "log_analytics" ? azurerm_log_analytics_workspace.management.id :
+          lock_name == "automation_account" ? azurerm_automation_account.management[0].id :
+          lock_name == "user_assigned_identities" ? azurerm_user_assigned_identity.management["ama"].id : null
+        )
+        } if lock_config.enabled && (
+        # Check if the corresponding resource actually exists using the same variables
+        lock_name == "resource_group" ? var.resource_group_creation_enabled :
+        lock_name == "log_analytics" ? true : # Log analytics always exists  
+        lock_name == "automation_account" ? var.linked_automation_account_creation_enabled :
+        lock_name == "user_assigned_identities" ? var.user_assigned_managed_identities.ama.enabled :
+        false
+      ) && lock_name != "data_collection_rules" # Exclude DCR from single resource handling
+    },
+    var.management_resource_locks.data_collection_rules.enabled ? {
+      for rule_name, rule_config in local.enabled_data_collection_rules : "data_collection_rules_${rule_name}" => {
+        lock_level = var.management_resource_locks.data_collection_rules.lock_level
+        scope      = azapi_resource.data_collection_rule[rule_name].id
+      }
+    } : {}
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -128,3 +128,12 @@ resource "azapi_resource" "data_collection_rule" {
     update = var.timeouts.data_collection_rule.update
   }
 }
+
+resource "azurerm_management_lock" "management" {
+  for_each = local.resource_locks_processed
+
+  name       = each.value.lock_level
+  scope      = each.value.scope
+  lock_level = each.value.lock_level
+  notes      = "Managed by avm-ptn-alz-management Terraform - ${each.value.lock_level} resource lock"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -308,3 +308,56 @@ The value of this variable is an object with the following attributes:
   - tags (Optional) - A map of tags to apply to the user assigned managed identity. Defaults to `null`.
 DESCRIPTION
 }
+
+variable "management_resource_locks" {
+  type = object({
+    resource_group = optional(object({
+      enabled    = optional(bool, false)
+      lock_level = optional(string, "CanNotDelete")
+      }), {
+      enabled    = false
+      lock_level = "CanNotDelete"
+    })
+    log_analytics = optional(object({
+      enabled    = optional(bool, false)
+      lock_level = optional(string, "CanNotDelete")
+      }), {
+      enabled    = false
+      lock_level = "CanNotDelete"
+    })
+    automation_account = optional(object({
+      enabled    = optional(bool, false)
+      lock_level = optional(string, "CanNotDelete")
+      }), {
+      enabled    = false
+      lock_level = "CanNotDelete"
+    })
+    user_assigned_identities = optional(object({
+      enabled    = optional(bool, false)
+      lock_level = optional(string, "CanNotDelete")
+      }), {
+      enabled    = false
+      lock_level = "CanNotDelete"
+    })
+    data_collection_rules = optional(object({
+      enabled    = optional(bool, false)
+      lock_level = optional(string, "CanNotDelete")
+      }), {
+      enabled    = false
+      lock_level = "CanNotDelete"
+    })
+  })
+
+  validation {
+    condition = alltrue([
+      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.resource_group.lock_level),
+      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.log_analytics.lock_level),
+      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.automation_account.lock_level),
+      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.user_assigned_identities.lock_level),
+      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.data_collection_rules.lock_level)
+    ])
+    error_message = "All lock_level values must be either 'CanNotDelete' or 'ReadOnly'."
+  }
+  default     = {}
+  description = "Resource Locks that can be assigned to management resources to prevent accidential deletion or modification."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -311,13 +311,6 @@ DESCRIPTION
 
 variable "management_resource_locks" {
   type = object({
-    resource_group = optional(object({
-      enabled    = optional(bool, false)
-      lock_level = optional(string, "CanNotDelete")
-      }), {
-      enabled    = false
-      lock_level = "CanNotDelete"
-    })
     log_analytics = optional(object({
       enabled    = optional(bool, false)
       lock_level = optional(string, "CanNotDelete")
@@ -350,7 +343,6 @@ variable "management_resource_locks" {
 
   validation {
     condition = alltrue([
-      contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.resource_group.lock_level),
       contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.log_analytics.lock_level),
       contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.automation_account.lock_level),
       contains(["CanNotDelete", "ReadOnly"], var.management_resource_locks.user_assigned_identities.lock_level),


### PR DESCRIPTION
## Description

Adds functionality to create resource locks on management resources. Will only create them if the related resources have been selected in vars

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
